### PR TITLE
Rename issue fixed:#56168

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/typescript-rename-issue.iml" filepath="$PROJECT_DIR$/.idea/typescript-rename-issue.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/typescript-rename-issue.iml
+++ b/.idea/typescript-rename-issue.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/client/src/helper.ts
+++ b/client/src/helper.ts
@@ -2,7 +2,7 @@ import type { Command, Diagnostic } from 'vscode';
 import { CodeAction, CodeActionKind, Position, Range } from 'vscode';
 import type { Command as LanguageClientCommand } from 'vscode-languageclient/node';
 import {
-    CodeAction as LcCodeAction,
+    CodeAction as LsCodeAction,
     Diagnostic as LcDiagnostic,
     Position as LcPosition,
     Range as LcRange,
@@ -11,11 +11,11 @@ import {
 import { diagSeverityMap } from './MapDiagnosticSeverity';
 import type { RangeLike } from './models';
 
-export function isLcCodeAction(c: LanguageClientCommand | LcCodeAction): c is LcCodeAction {
-    return LcCodeAction.is(c);
+export function isLcCodeAction(c: LanguageClientCommand | LsCodeAction): c is LsCodeAction {
+    return LsCodeAction.is(c);
 }
 
-export function mapLcCodeAction(c: LcCodeAction): CodeAction {
+export function mapLcCodeAction(c: LsCodeAction): CodeAction {
     const kind = (c.kind !== undefined && CodeActionKind.Empty.append(c.kind)) || undefined;
     const action = new CodeAction(c.title, kind);
     action.command = c.command && mapLcCommand(c.command);


### PR DESCRIPTION
Typescript Rename issue fixed
Fixed Issue: #56168
i was able to rename the import from LcCodeAction to LsCodeAction in the code
As per Expected behavior:
Only the local variables in the current file are changed.
<img width="1440" alt="Screenshot 2023-11-03 at 1 48 07 PM" src="https://github.com/Jason3S/typescript-rename-issue/assets/36887536/317f0e02-7035-48ba-915e-16747ab8198a">
